### PR TITLE
fixes(init.lua): replace fn.expand with fn.stdpath

### DIFF
--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -35,11 +35,11 @@ end
 -- locate the binary here, as expand is relative to the calling script name
 local binary = nil
 if fn.has("mac") == 1 then
-	binary = fn.expand("<sfile>:p:h:h:h") .. "/binaries/TabNine_Darwin"
+	binary = fn.stdpath('data') .. '/site/pack/packer/start/compe-tabnine/binaries/TabNine_Darwin'
 elseif fn.has('unix') == 1 then
-	binary = fn.expand("<sfile>:p:h:h:h") .. "/binaries/TabNine_Linux"
+	binary = fn.stdpath('data') .. '/site/pack/packer/start/compe-tabnine/binaries/TabNine_Linux'
 else
-	binary = fn.expand("<sfile>:p:h:h:h") .. "/binaries/TabNine_Windows"
+	binary = fn.stdpath('data') .. '/site/pack/packer/start/compe-tabnine/binaries/TabNine_Windows'
 end
 
 local function is_enabled()


### PR DESCRIPTION
This fixes a bug that breaks the import path for Neovim on Arch Linux.